### PR TITLE
Feature/secret to public bridge

### DIFF
--- a/NovaCrypto.podspec
+++ b/NovaCrypto.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NovaCrypto'
-  s.version          = '0.4.0'
+  s.version          = '0.4.1'
   s.summary          = 'Provides object oriented wrappers for C/C++ crypto functions used by blockchains.'
 
   s.homepage         = 'https://github.com/novasamatech/Crypto-iOS'

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2b222f6d99df922b3be61fc07ae1d1a92d3d035bfd594daf9b20039635187afe",
+  "originHash" : "fe22ae4e2373f60d0dd354b26c6b331d2035438eb9eb7c3277330143f0c44908",
   "pins" : [
     {
       "identity" : "blake2.c",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/novasamatech/sr25519.c.git",
       "state" : {
-        "revision" : "a7b119eff15c724982c4641d279a90f2548d968c",
-        "version" : "0.2.0"
+        "branch" : "feature/public-from-secret",
+        "revision" : "e50b7e0f0340e3280f140093a4ff831da1dc95b9"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/novasamatech/secp256k1.c.git", exact: "0.1.4"),
         .package(url: "https://github.com/novasamatech/ed25519.c.git", exact: "0.1.2"),
-        .package(url: "https://github.com/novasamatech/sr25519.c.git", exact: "0.2.0"),
-        .package(url: "https://github.com/novasamatech/sr25519.c.git", branch: "public-from-secret"),
+        .package(url: "https://github.com/novasamatech/sr25519.c.git", branch: "feature/public-from-secret"),
         .package(url: "https://github.com/novasamatech/blake2.c", exact: "0.1.1")
     ],
     targets: targets + testTargets,

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/novasamatech/secp256k1.c.git", exact: "0.1.4"),
         .package(url: "https://github.com/novasamatech/ed25519.c.git", exact: "0.1.2"),
-        .package(url: "https://github.com/novasamatech/sr25519.c.git", branch: "feature/public-from-secret"),
+        .package(url: "https://github.com/novasamatech/sr25519.c.git", exact: "0.2.1"),
         .package(url: "https://github.com/novasamatech/blake2.c", exact: "0.1.1")
     ],
     targets: targets + testTargets,

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(url: "https://github.com/novasamatech/secp256k1.c.git", exact: "0.1.4"),
         .package(url: "https://github.com/novasamatech/ed25519.c.git", exact: "0.1.2"),
         .package(url: "https://github.com/novasamatech/sr25519.c.git", exact: "0.2.0"),
+        .package(url: "https://github.com/novasamatech/sr25519.c.git", branch: "public-from-secret"),
         .package(url: "https://github.com/novasamatech/blake2.c", exact: "0.1.1")
     ],
     targets: targets + testTargets,

--- a/Sources/sr25519/SNKeyFactory.h
+++ b/Sources/sr25519/SNKeyFactory.h
@@ -10,7 +10,8 @@
 
 typedef NS_ENUM(NSUInteger, SNKeyFactoryError) {
     SNKeyFactoryErrorInvalidSeed,
-    SNKeyFactoryErrorInvalidChaincode
+    SNKeyFactoryErrorInvalidChaincode,
+    SNKeyFactoryErrorInvalidSecret
 };
 
 @protocol SNKeyFactoryProtocol

--- a/Sources/sr25519/SNKeyFactory.h
+++ b/Sources/sr25519/SNKeyFactory.h
@@ -30,6 +30,9 @@ typedef NS_ENUM(NSUInteger, SNKeyFactoryError) {
                                    chaincode:(nonnull NSData*)chaincode
                                        error:(NSError*_Nullable*_Nullable)error;
 
+- (nullable SNPublicKey*)createPublicKeyFromSecret:(nonnull NSData*)secret
+                                       error:(NSError*_Nullable*_Nullable)error;
+
 @end
 
 @interface SNKeyFactory : NSObject<SNKeyFactoryProtocol>

--- a/Sources/sr25519/SNKeyFactory.m
+++ b/Sources/sr25519/SNKeyFactory.m
@@ -93,6 +93,28 @@
     return [[SNPublicKey alloc] initWithRawData:publicKeyData error:error];
 }
 
+- (nullable SNPublicKey*)createPublicKeyFromSecret:(nonnull NSData*)secret
+                                             error:(NSError*_Nullable*_Nullable)error {
+    if (secret.length != SR25519_SECRET_SIZE) {
+        if (error) {
+            NSString *message = [NSString stringWithFormat:@"Invalid secret length %@ but expected %@",
+                                 @(secret.length), @(SR25519_SECRET_SIZE)];
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:SNKeyFactoryErrorInvalidSecret
+                                     userInfo:@{NSLocalizedDescriptionKey : message}];
+        }
+        return nil;
+    }
+    
+    uint8_t publicKeyBytes[SR25519_PUBLIC_SIZE];
+    
+    sr25519_secret_to_public_key(publicKeyBytes, secret.bytes);
+    
+    NSData *publicKeyData = [NSData dataWithBytes:publicKeyBytes length:SR25519_PUBLIC_SIZE];
+    
+    return [[SNPublicKey alloc] initWithRawData:publicKeyData error:error];
+}
+
 + (nonnull NSError*)createChainCodeError:(NSUInteger)actualSize {
     NSString *message = [NSString stringWithFormat:@"Invalid chaincode length %@ but expected %@",
                          @(actualSize), @(SR25519_CHAINCODE_SIZE)];

--- a/Sources/sr25519/SNKeyFactory.m
+++ b/Sources/sr25519/SNKeyFactory.m
@@ -88,7 +88,7 @@
 
     sr25519_derive_public_soft(publicKeyBytes, parentPublicKey.rawData.bytes, chaincode.bytes);
 
-    NSData *publicKeyData = [NSData dataWithBytes:publicKeyBytes length:SR25519_KEYPAIR_SIZE];
+    NSData *publicKeyData = [NSData dataWithBytes:publicKeyBytes length:SR25519_PUBLIC_SIZE];
 
     return [[SNPublicKey alloc] initWithRawData:publicKeyData error:error];
 }


### PR DESCRIPTION
### SUMMARY

The PR adds a bridge function to support public key derivation from substrate secret.

Also, there is fix for incorrect bytes length allocation in `createPublicKeySoft` function. 