### PR TITLE
Integrate new sr25519.c

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "da4d2a8c7b95bf12f0010f8a3f1247d489bb27bf7cc6ae65627bf38e5d6cb6e4",
+  "originHash" : "0ee52ac5c065d508a1644e2eeb793932d1d310ddd25d6837c8a1aa67244313e7",
   "pins" : [
     {
       "identity" : "blake2.c",
@@ -33,7 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/novasamatech/sr25519.c.git",
       "state" : {
-        "revision" : "24134dc0e110fa7c3ca6bc4e55ff6fdc7f27728f"
+        "revision" : "5cc5cb2499577451a0f9a21ab4c405838b18ef97"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe22ae4e2373f60d0dd354b26c6b331d2035438eb9eb7c3277330143f0c44908",
+  "originHash" : "da4d2a8c7b95bf12f0010f8a3f1247d489bb27bf7cc6ae65627bf38e5d6cb6e4",
   "pins" : [
     {
       "identity" : "blake2.c",
@@ -33,8 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/novasamatech/sr25519.c.git",
       "state" : {
-        "branch" : "feature/public-from-secret",
-        "revision" : "e50b7e0f0340e3280f140093a4ff831da1dc95b9"
+        "revision" : "24134dc0e110fa7c3ca6bc4e55ff6fdc7f27728f"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0ee52ac5c065d508a1644e2eeb793932d1d310ddd25d6837c8a1aa67244313e7",
+  "originHash" : "241512ea2a2e9a2ce60445da753fb53b248be781541edb2a924d0d28275134a3",
   "pins" : [
     {
       "identity" : "blake2.c",
@@ -33,7 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/novasamatech/sr25519.c.git",
       "state" : {
-        "revision" : "5cc5cb2499577451a0f9a21ab4c405838b18ef97"
+        "revision" : "8ffec3fe0f0b169eaaba2537a3c66ff38fdb25df",
+        "version" : "0.3.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/novasamatech/secp256k1.c.git", exact: "0.1.4"),
         .package(url: "https://github.com/novasamatech/ed25519.c.git", exact: "0.1.2"),
-        .package(url: "https://github.com/novasamatech/sr25519.c.git", revision: "24134dc0e110fa7c3ca6bc4e55ff6fdc7f27728f"),
+        .package(url: "https://github.com/novasamatech/sr25519.c.git", revision: "5cc5cb2499577451a0f9a21ab4c405838b18ef97"),
         .package(url: "https://github.com/novasamatech/blake2.c", exact: "0.1.1")
     ],
     targets: targets + testTargets,

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/novasamatech/secp256k1.c.git", exact: "0.1.4"),
         .package(url: "https://github.com/novasamatech/ed25519.c.git", exact: "0.1.2"),
-        .package(url: "https://github.com/novasamatech/sr25519.c.git", revision: "5cc5cb2499577451a0f9a21ab4c405838b18ef97"),
+        .package(url: "https://github.com/novasamatech/sr25519.c.git", exact: "0.3.0"),
         .package(url: "https://github.com/novasamatech/blake2.c", exact: "0.1.1")
     ],
     targets: targets + testTargets,

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/novasamatech/secp256k1.c.git", exact: "0.1.4"),
         .package(url: "https://github.com/novasamatech/ed25519.c.git", exact: "0.1.2"),
-        .package(url: "https://github.com/novasamatech/sr25519.c.git", exact: "0.2.1"),
+        .package(url: "https://github.com/novasamatech/sr25519.c.git", revision: "24134dc0e110fa7c3ca6bc4e55ff6fdc7f27728f"),
         .package(url: "https://github.com/novasamatech/blake2.c", exact: "0.1.1")
     ],
     targets: targets + testTargets,

--- a/Sources/sr25519/SNKeyFactory.m
+++ b/Sources/sr25519/SNKeyFactory.m
@@ -26,7 +26,7 @@
 
     uint8_t keypair[SR25519_KEYPAIR_SIZE];
 
-    Sr25519SignatureResult result = sr25519_keypair_from_seed(keypair, seed.bytes);
+    Sr25519Result result = sr25519_keypair_from_seed(keypair, seed.bytes);
 
     if (result != Ok) {
         if (error) {
@@ -55,7 +55,7 @@
 
     uint8_t keypair[SR25519_KEYPAIR_SIZE];
 
-    Sr25519SignatureResult result = sr25519_derive_keypair_hard(keypair, parent.rawData.bytes, chaincode.bytes);
+    Sr25519Result result = sr25519_derive_keypair_hard(keypair, parent.rawData.bytes, chaincode.bytes);
 
     if (result != Ok) {
         if (error) {
@@ -84,7 +84,7 @@
 
     uint8_t keypair[SR25519_KEYPAIR_SIZE];
 
-    Sr25519SignatureResult result = sr25519_derive_keypair_soft(keypair, parent.rawData.bytes, chaincode.bytes);
+    Sr25519Result result = sr25519_derive_keypair_soft(keypair, parent.rawData.bytes, chaincode.bytes);
 
     if (result != Ok) {
         if (error) {
@@ -113,7 +113,7 @@
 
     uint8_t publicKeyBytes[SR25519_PUBLIC_SIZE];
 
-    Sr25519SignatureResult result = sr25519_derive_public_soft(publicKeyBytes, parentPublicKey.rawData.bytes, chaincode.bytes);
+    Sr25519Result result = sr25519_derive_public_soft(publicKeyBytes, parentPublicKey.rawData.bytes, chaincode.bytes);
 
     if (result != Ok) {
         if (error) {
@@ -144,7 +144,7 @@
 
     uint8_t publicKeyBytes[SR25519_PUBLIC_SIZE];
 
-    Sr25519SignatureResult result = sr25519_secret_to_public_key(publicKeyBytes, secret.bytes);
+    Sr25519Result result = sr25519_secret_to_public_key(publicKeyBytes, secret.bytes);
 
     if (result != Ok) {
         if (error) {

--- a/Sources/sr25519/SNKeyFactory.m
+++ b/Sources/sr25519/SNKeyFactory.m
@@ -8,30 +8,6 @@
 #import "SNKeyFactory.h"
 #import "sr25519.h"
 
-// MARK: - Canonical scalar validation (schnorrkel 0.9.1 from_bytes)
-// Curve25519 group order L = 2^252 + 27742317777372353535851937790883648493, LE.
-static const uint8_t SNRistrettoGroupOrder[32] = {
-    0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
-    0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10
-};
-
-// Returns YES iff s (LE, 32 bytes) is strictly less than L.
-static BOOL SNIsCanonicalScalar(const uint8_t s[32]) {
-    for (int i = 31; i >= 0; i--) {
-        if (s[i] < SNRistrettoGroupOrder[i]) return YES;
-        if (s[i] > SNRistrettoGroupOrder[i]) return NO;
-    }
-    return NO; // s == L rejected
-}
-
-static BOOL SNIsValidCanonicalScalar(const uint8_t s[32]) {
-    BOOL nonZero = NO;
-    for (int i = 0; i < 32; i++) if (s[i]) { nonZero = YES; break; }
-    return nonZero && SNIsCanonicalScalar(s);
-}
-
 @implementation SNKeyFactory
 
 - (id<SNKeypairProtocol> _Nullable)createKeypairFromSeed:(nonnull NSData*)seed
@@ -49,8 +25,17 @@ static BOOL SNIsValidCanonicalScalar(const uint8_t s[32]) {
     }
 
     uint8_t keypair[SR25519_KEYPAIR_SIZE];
-    
-    sr25519_keypair_from_seed(keypair, seed.bytes);
+
+    Sr25519SignatureResult result = sr25519_keypair_from_seed(keypair, seed.bytes);
+
+    if (result != Ok) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:SNKeyFactoryErrorInvalidSeed
+                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 keypair creation from seed failed"}];
+        }
+        return nil;
+    }
 
     NSData *keypairData = [NSData dataWithBytes:keypair length:SR25519_KEYPAIR_SIZE];
 
@@ -70,7 +55,16 @@ static BOOL SNIsValidCanonicalScalar(const uint8_t s[32]) {
 
     uint8_t keypair[SR25519_KEYPAIR_SIZE];
 
-    sr25519_derive_keypair_hard(keypair, parent.rawData.bytes, chaincode.bytes);
+    Sr25519SignatureResult result = sr25519_derive_keypair_hard(keypair, parent.rawData.bytes, chaincode.bytes);
+
+    if (result != Ok) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:SNKeyFactoryErrorInvalidSeed
+                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 hard derivation failed"}];
+        }
+        return nil;
+    }
 
     NSData *keypairData = [NSData dataWithBytes:keypair length:SR25519_KEYPAIR_SIZE];
 
@@ -90,7 +84,16 @@ static BOOL SNIsValidCanonicalScalar(const uint8_t s[32]) {
 
     uint8_t keypair[SR25519_KEYPAIR_SIZE];
 
-    sr25519_derive_keypair_soft(keypair, parent.rawData.bytes, chaincode.bytes);
+    Sr25519SignatureResult result = sr25519_derive_keypair_soft(keypair, parent.rawData.bytes, chaincode.bytes);
+
+    if (result != Ok) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:SNKeyFactoryErrorInvalidSeed
+                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 soft derivation failed"}];
+        }
+        return nil;
+    }
 
     NSData *keypairData = [NSData dataWithBytes:keypair length:SR25519_KEYPAIR_SIZE];
 
@@ -110,7 +113,16 @@ static BOOL SNIsValidCanonicalScalar(const uint8_t s[32]) {
 
     uint8_t publicKeyBytes[SR25519_PUBLIC_SIZE];
 
-    sr25519_derive_public_soft(publicKeyBytes, parentPublicKey.rawData.bytes, chaincode.bytes);
+    Sr25519SignatureResult result = sr25519_derive_public_soft(publicKeyBytes, parentPublicKey.rawData.bytes, chaincode.bytes);
+
+    if (result != Ok) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:SNKeyFactoryErrorInvalidSecret
+                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 public key soft derivation failed"}];
+        }
+        return nil;
+    }
 
     NSData *publicKeyData = [NSData dataWithBytes:publicKeyBytes length:SR25519_PUBLIC_SIZE];
 
@@ -129,26 +141,22 @@ static BOOL SNIsValidCanonicalScalar(const uint8_t s[32]) {
         }
         return nil;
     }
-    // Mirror schnorrkel 0.9.1 SecretKey::from_bytes Scalar::from_canonical_bytes:
-    //   1. high bit of scalar must be clear
-    //   2. scalar must be < L (canonical)
-    // Failing either causes Rust panic in create_secret
-    const uint8_t *s = secret.bytes;
-    if ((s[31] & 0x80) != 0 || !SNIsValidCanonicalScalar(s)) {
+
+    uint8_t publicKeyBytes[SR25519_PUBLIC_SIZE];
+
+    Sr25519SignatureResult result = sr25519_secret_to_public_key(publicKeyBytes, secret.bytes);
+
+    if (result != Ok) {
         if (error) {
             *error = [NSError errorWithDomain:NSStringFromClass([self class])
                                          code:SNKeyFactoryErrorInvalidSecret
-                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 secret scalar is not canonical (>= group order)"}];
+                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 secret key is invalid"}];
         }
         return nil;
     }
-    
-    uint8_t publicKeyBytes[SR25519_PUBLIC_SIZE];
-    
-    sr25519_secret_to_public_key(publicKeyBytes, secret.bytes);
-    
+
     NSData *publicKeyData = [NSData dataWithBytes:publicKeyBytes length:SR25519_PUBLIC_SIZE];
-    
+
     return [[SNPublicKey alloc] initWithRawData:publicKeyData error:error];
 }
 

--- a/Sources/sr25519/SNPrivateKey.h
+++ b/Sources/sr25519/SNPrivateKey.h
@@ -13,6 +13,6 @@
 - (nullable instancetype)initWithFromEd25519:(nonnull NSData*)data
                                        error:(NSError*_Nullable*_Nullable)error;
 
-- (nonnull NSData*)toEd25519Data;
+- (nullable NSData*)toEd25519Data;
 
 @end

--- a/Sources/sr25519/SNPrivateKey.m
+++ b/Sources/sr25519/SNPrivateKey.m
@@ -55,7 +55,16 @@
 
     if (self = [super init]) {
         uint8_t secret_out[SR25519_SECRET_SIZE];
-        sr25519_from_ed25519_bytes(secret_out, data.bytes);
+        Sr25519SignatureResult result = sr25519_from_ed25519_bytes(secret_out, data.bytes);
+
+        if (result != Ok) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                             code:IRCryptoKeyErrorInvalidRawData
+                                         userInfo:@{NSLocalizedDescriptionKey: @"sr25519 conversion from ed25519 failed"}];
+            }
+            return nil;
+        }
 
         self.rawData = [NSData dataWithBytes:secret_out length:SR25519_SECRET_SIZE];
     }
@@ -63,9 +72,13 @@
     return self;
 }
 
-- (nonnull NSData*)toEd25519Data {
+- (nullable NSData*)toEd25519Data {
     uint8_t secret_out[SR25519_SECRET_SIZE];
-    sr25519_to_ed25519_bytes(secret_out, _rawData.bytes);
+    Sr25519SignatureResult result = sr25519_to_ed25519_bytes(secret_out, _rawData.bytes);
+
+    if (result != Ok) {
+        return nil;
+    }
 
     return [NSData dataWithBytes:secret_out length:SR25519_SECRET_SIZE];
 }

--- a/Sources/sr25519/SNPrivateKey.m
+++ b/Sources/sr25519/SNPrivateKey.m
@@ -55,7 +55,7 @@
 
     if (self = [super init]) {
         uint8_t secret_out[SR25519_SECRET_SIZE];
-        Sr25519SignatureResult result = sr25519_from_ed25519_bytes(secret_out, data.bytes);
+        Sr25519Result result = sr25519_from_ed25519_bytes(secret_out, data.bytes);
 
         if (result != Ok) {
             if (error) {
@@ -74,7 +74,7 @@
 
 - (nullable NSData*)toEd25519Data {
     uint8_t secret_out[SR25519_SECRET_SIZE];
-    Sr25519SignatureResult result = sr25519_to_ed25519_bytes(secret_out, _rawData.bytes);
+    Sr25519Result result = sr25519_to_ed25519_bytes(secret_out, _rawData.bytes);
 
     if (result != Ok) {
         return nil;

--- a/Sources/sr25519/SNSigner.m
+++ b/Sources/sr25519/SNSigner.m
@@ -28,7 +28,7 @@
                               error:(NSError*_Nullable*_Nullable)error {
     uint8_t signatureBytes[SR25519_SIGNATURE_SIZE];
 
-    Sr25519SignatureResult result = sr25519_sign(signatureBytes,
+    Sr25519Result result = sr25519_sign(signatureBytes,
                  _keypair.publicKey.rawData.bytes,
                  _keypair.privateKey.rawData.bytes,
                  originalData.bytes,

--- a/Sources/sr25519/SNSigner.m
+++ b/Sources/sr25519/SNSigner.m
@@ -28,15 +28,24 @@
                               error:(NSError*_Nullable*_Nullable)error {
     uint8_t signatureBytes[SR25519_SIGNATURE_SIZE];
 
-    sr25519_sign(signatureBytes,
+    Sr25519SignatureResult result = sr25519_sign(signatureBytes,
                  _keypair.publicKey.rawData.bytes,
                  _keypair.privateKey.rawData.bytes,
                  originalData.bytes,
                  originalData.length);
 
+    if (result != Ok) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:0
+                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 signing failed"}];
+        }
+        return nil;
+    }
+
     NSData *signatureData = [NSData dataWithBytes:signatureBytes length:SR25519_SIGNATURE_SIZE];
 
-    return [[SNSignature alloc] initWithRawData:signatureData error:error];;
+    return [[SNSignature alloc] initWithRawData:signatureData error:error];
 }
 
 @end

--- a/Sources/sr25519/SNVrfField.h
+++ b/Sources/sr25519/SNVrfField.h
@@ -1,0 +1,17 @@
+//
+//  SNVrfField.h
+//  IrohaCrypto
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SNVrfField : NSObject
+
+@property(nonatomic, readonly, nonnull) NSData *key;
+@property(nonatomic, readonly, nonnull) NSData *value;
+
+- (nonnull instancetype)initWithKey:(nonnull NSData*)key value:(nonnull NSData*)value;
+
++ (nonnull instancetype)fieldWithKey:(nonnull NSString*)key value:(nonnull NSData*)value;
+
+@end

--- a/Sources/sr25519/SNVrfField.m
+++ b/Sources/sr25519/SNVrfField.m
@@ -1,0 +1,29 @@
+//
+//  SNVrfField.m
+//  IrohaCrypto
+//
+
+#import "SNVrfField.h"
+
+@interface SNVrfField()
+
+@property(copy, nonatomic) NSData *key;
+@property(copy, nonatomic) NSData *value;
+
+@end
+
+@implementation SNVrfField
+
+- (nonnull instancetype)initWithKey:(nonnull NSData*)key value:(nonnull NSData*)value {
+    if (self = [super init]) {
+        self.key = key;
+        self.value = value;
+    }
+    return self;
+}
+
++ (nonnull instancetype)fieldWithKey:(nonnull NSString*)key value:(nonnull NSData*)value {
+    return [[self alloc] initWithKey:[key dataUsingEncoding:NSUTF8StringEncoding] value:value];
+}
+
+@end

--- a/Sources/sr25519/SNVrfSignature.h
+++ b/Sources/sr25519/SNVrfSignature.h
@@ -1,0 +1,25 @@
+//
+//  SNVrfSignature.h
+//  IrohaCrypto
+//
+
+#import <Foundation/Foundation.h>
+
+extern const NSUInteger SNVrfPreOutputSize;
+extern const NSUInteger SNVrfProofSize;
+
+@interface SNVrfSignature : NSObject
+
+@property(nonatomic, readonly, nonnull) NSData *preOutput;
+@property(nonatomic, readonly, nonnull) NSData *proof;
+
+- (nullable instancetype)initWithPreOutput:(nonnull NSData*)preOutput
+                                     proof:(nonnull NSData*)proof
+                                     error:(NSError*_Nullable*_Nullable)error;
+
+- (nullable instancetype)initWithRawData:(nonnull NSData*)data
+                                   error:(NSError*_Nullable*_Nullable)error;
+
+- (nonnull NSData*)rawData;
+
+@end

--- a/Sources/sr25519/SNVrfSignature.h
+++ b/Sources/sr25519/SNVrfSignature.h
@@ -5,9 +5,6 @@
 
 #import <Foundation/Foundation.h>
 
-extern const NSUInteger SNVrfPreOutputSize;
-extern const NSUInteger SNVrfProofSize;
-
 @interface SNVrfSignature : NSObject
 
 @property(nonatomic, readonly, nonnull) NSData *preOutput;

--- a/Sources/sr25519/SNVrfSignature.m
+++ b/Sources/sr25519/SNVrfSignature.m
@@ -6,9 +6,6 @@
 #import "SNVrfSignature.h"
 #import "sr25519.h"
 
-const NSUInteger SNVrfPreOutputSize = SR25519_VRF_OUTPUT_SIZE;
-const NSUInteger SNVrfProofSize = SR25519_VRF_PROOF_SIZE;
-
 @interface SNVrfSignature()
 
 @property(copy, nonatomic) NSData *preOutput;
@@ -21,7 +18,7 @@ const NSUInteger SNVrfProofSize = SR25519_VRF_PROOF_SIZE;
 - (nullable instancetype)initWithPreOutput:(nonnull NSData*)preOutput
                                      proof:(nonnull NSData*)proof
                                      error:(NSError*_Nullable*_Nullable)error {
-    if (preOutput.length != SNVrfPreOutputSize || proof.length != SNVrfProofSize) {
+    if (preOutput.length != SR25519_VRF_OUTPUT_SIZE || proof.length != SR25519_VRF_PROOF_SIZE) {
         if (error) {
             *error = [NSError errorWithDomain:NSStringFromClass([self class])
                                          code:0
@@ -40,7 +37,7 @@ const NSUInteger SNVrfProofSize = SR25519_VRF_PROOF_SIZE;
 
 - (nullable instancetype)initWithRawData:(nonnull NSData*)data
                                    error:(NSError*_Nullable*_Nullable)error {
-    if (data.length != SNVrfPreOutputSize + SNVrfProofSize) {
+    if (data.length != SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE) {
         if (error) {
             *error = [NSError errorWithDomain:NSStringFromClass([self class])
                                          code:0
@@ -50,15 +47,15 @@ const NSUInteger SNVrfProofSize = SR25519_VRF_PROOF_SIZE;
     }
 
     if (self = [super init]) {
-        self.preOutput = [data subdataWithRange:NSMakeRange(0, SNVrfPreOutputSize)];
-        self.proof = [data subdataWithRange:NSMakeRange(SNVrfPreOutputSize, SNVrfProofSize)];
+        self.preOutput = [data subdataWithRange:NSMakeRange(0, SR25519_VRF_OUTPUT_SIZE)];
+        self.proof = [data subdataWithRange:NSMakeRange(SR25519_VRF_OUTPUT_SIZE, SR25519_VRF_PROOF_SIZE)];
     }
 
     return self;
 }
 
 - (nonnull NSData*)rawData {
-    NSMutableData *data = [NSMutableData dataWithCapacity:SNVrfPreOutputSize + SNVrfProofSize];
+    NSMutableData *data = [NSMutableData dataWithCapacity:SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE];
     [data appendData:self.preOutput];
     [data appendData:self.proof];
     return data;

--- a/Sources/sr25519/SNVrfSignature.m
+++ b/Sources/sr25519/SNVrfSignature.m
@@ -1,0 +1,67 @@
+//
+//  SNVrfSignature.m
+//  IrohaCrypto
+//
+
+#import "SNVrfSignature.h"
+#import "sr25519.h"
+
+const NSUInteger SNVrfPreOutputSize = SR25519_VRF_OUTPUT_SIZE;
+const NSUInteger SNVrfProofSize = SR25519_VRF_PROOF_SIZE;
+
+@interface SNVrfSignature()
+
+@property(copy, nonatomic) NSData *preOutput;
+@property(copy, nonatomic) NSData *proof;
+
+@end
+
+@implementation SNVrfSignature
+
+- (nullable instancetype)initWithPreOutput:(nonnull NSData*)preOutput
+                                     proof:(nonnull NSData*)proof
+                                     error:(NSError*_Nullable*_Nullable)error {
+    if (preOutput.length != SNVrfPreOutputSize || proof.length != SNVrfProofSize) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:0
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Invalid VRF signature component sizes"}];
+        }
+        return nil;
+    }
+
+    if (self = [super init]) {
+        self.preOutput = preOutput;
+        self.proof = proof;
+    }
+
+    return self;
+}
+
+- (nullable instancetype)initWithRawData:(nonnull NSData*)data
+                                   error:(NSError*_Nullable*_Nullable)error {
+    if (data.length != SNVrfPreOutputSize + SNVrfProofSize) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:0
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Invalid VRF signature raw data size"}];
+        }
+        return nil;
+    }
+
+    if (self = [super init]) {
+        self.preOutput = [data subdataWithRange:NSMakeRange(0, SNVrfPreOutputSize)];
+        self.proof = [data subdataWithRange:NSMakeRange(SNVrfPreOutputSize, SNVrfProofSize)];
+    }
+
+    return self;
+}
+
+- (nonnull NSData*)rawData {
+    NSMutableData *data = [NSMutableData dataWithCapacity:SNVrfPreOutputSize + SNVrfProofSize];
+    [data appendData:self.preOutput];
+    [data appendData:self.proof];
+    return data;
+}
+
+@end

--- a/Sources/sr25519/SNVrfSigner.h
+++ b/Sources/sr25519/SNVrfSigner.h
@@ -1,0 +1,24 @@
+//
+//  SNVrfSigner.h
+//  IrohaCrypto
+//
+
+#import <Foundation/Foundation.h>
+#import "SNKeypair.h"
+#import "SNVrfSignature.h"
+#import "SNVrfField.h"
+
+typedef NS_ENUM(NSUInteger, SNVrfSignerError) {
+    SNVrfSignerErrorSigningFailed
+};
+
+@interface SNVrfSigner : NSObject
+
+- (nonnull instancetype)initWithKeypair:(id<SNKeypairProtocol> _Nonnull)keypair;
+
+/// Sign a VRF transcript with the given label and key-value fields.
+- (nullable SNVrfSignature*)signWithLabel:(nonnull NSData*)label
+                                   fields:(nonnull NSArray<SNVrfField*>*)fields
+                                    error:(NSError*_Nullable*_Nullable)error;
+
+@end

--- a/Sources/sr25519/SNVrfSigner.m
+++ b/Sources/sr25519/SNVrfSigner.m
@@ -1,0 +1,76 @@
+//
+//  SNVrfSigner.m
+//  IrohaCrypto
+//
+
+#import "SNVrfSigner.h"
+#import "sr25519.h"
+
+@interface SNVrfSigner()
+
+@property(strong, nonatomic) _Nonnull id<SNKeypairProtocol> keypair;
+
+@end
+
+@implementation SNVrfSigner
+
+- (nonnull instancetype)initWithKeypair:(id<SNKeypairProtocol> _Nonnull)keypair {
+    if (self = [super init]) {
+        self.keypair = keypair;
+    }
+    return self;
+}
+
+- (nullable SNVrfSignature*)signWithLabel:(nonnull NSData*)label
+                                   fields:(nonnull NSArray<SNVrfField*>*)fields
+                                    error:(NSError*_Nullable*_Nullable)error {
+    NSUInteger count = fields.count;
+    VrfTranscriptField *cFields = NULL;
+
+    if (count > 0) {
+        cFields = calloc(count, sizeof(VrfTranscriptField));
+        if (!cFields) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                             code:SNVrfSignerErrorSigningFailed
+                                         userInfo:@{NSLocalizedDescriptionKey: @"Memory allocation failed"}];
+            }
+            return nil;
+        }
+
+        for (NSUInteger i = 0; i < count; i++) {
+            SNVrfField *field = fields[i];
+            cFields[i].key = field.key.bytes;
+            cFields[i].key_length = field.key.length;
+            cFields[i].value = field.value.bytes;
+            cFields[i].value_length = field.value.length;
+        }
+    }
+
+    uint8_t out[SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE];
+
+    Sr25519Result result = sr25519_generic_vrf_sign(
+        out,
+        _keypair.rawData.bytes,
+        label.bytes,
+        label.length,
+        cFields,
+        count
+    );
+
+    free(cFields);
+
+    if (result != Ok) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSStringFromClass([self class])
+                                         code:SNVrfSignerErrorSigningFailed
+                                     userInfo:@{NSLocalizedDescriptionKey: @"sr25519 VRF signing failed"}];
+        }
+        return nil;
+    }
+
+    NSData *rawData = [NSData dataWithBytes:out length:sizeof(out)];
+    return [[SNVrfSignature alloc] initWithRawData:rawData error:error];
+}
+
+@end

--- a/Sources/sr25519/SNVrfVerifier.h
+++ b/Sources/sr25519/SNVrfVerifier.h
@@ -1,0 +1,19 @@
+//
+//  SNVrfVerifier.h
+//  IrohaCrypto
+//
+
+#import <Foundation/Foundation.h>
+#import "SNPublicKey.h"
+#import "SNVrfSignature.h"
+#import "SNVrfField.h"
+
+@interface SNVrfVerifier : NSObject
+
+/// Verify a VRF signature against a public key, label, and key-value fields.
+- (BOOL)verify:(nonnull SNVrfSignature*)signature
+     publicKey:(nonnull SNPublicKey*)publicKey
+         label:(nonnull NSData*)label
+        fields:(nonnull NSArray<SNVrfField*>*)fields;
+
+@end

--- a/Sources/sr25519/SNVrfVerifier.m
+++ b/Sources/sr25519/SNVrfVerifier.m
@@ -1,0 +1,48 @@
+//
+//  SNVrfVerifier.m
+//  IrohaCrypto
+//
+
+#import "SNVrfVerifier.h"
+#import "sr25519.h"
+
+@implementation SNVrfVerifier
+
+- (BOOL)verify:(nonnull SNVrfSignature*)signature
+     publicKey:(nonnull SNPublicKey*)publicKey
+         label:(nonnull NSData*)label
+        fields:(nonnull NSArray<SNVrfField*>*)fields {
+    NSUInteger count = fields.count;
+    VrfTranscriptField *cFields = NULL;
+
+    if (count > 0) {
+        cFields = calloc(count, sizeof(VrfTranscriptField));
+        if (!cFields) {
+            return NO;
+        }
+
+        for (NSUInteger i = 0; i < count; i++) {
+            SNVrfField *field = fields[i];
+            cFields[i].key = field.key.bytes;
+            cFields[i].key_length = field.key.length;
+            cFields[i].value = field.value.bytes;
+            cFields[i].value_length = field.value.length;
+        }
+    }
+
+    Sr25519Result result = sr25519_generic_vrf_verify(
+        publicKey.rawData.bytes,
+        label.bytes,
+        label.length,
+        cFields,
+        count,
+        signature.preOutput.bytes,
+        signature.proof.bytes
+    );
+
+    free(cFields);
+
+    return result == Ok;
+}
+
+@end

--- a/Tests/SR25519/SNKeyFactoryTests.m
+++ b/Tests/SR25519/SNKeyFactoryTests.m
@@ -100,17 +100,6 @@ enum {
     }
 }
 
-/// Build a canonical ed25519-style 64-byte secret: low 3 bits of byte 0 clear,
-/// top 3 bits of byte 31 == 0b010.
-- (NSData *)canonicalSecretFromPattern:(uint8_t)fill {
-    uint8_t bytes[kSecretSize];
-    memset(bytes, fill, kSecretSize);
-    bytes[0]  &= 0xF8;             // clear low 3 bits
-    bytes[31] &= 0x7F;             // clear bit 7
-    bytes[31] = (bytes[31] & 0x3F) | 0x40; // top 3 bits = 010
-    return [NSData dataWithBytes:bytes length:kSecretSize];
-}
-
 #pragma mark - Length guard
 
 - (void)testReturnsNilAndErrorOnShortSecret {
@@ -166,17 +155,15 @@ enum {
     XCTAssertEqualObjects(derived.rawData, keypair.publicKey.rawData);
 }
 
-#pragma mark - Non-canonical input (documented FFI crash)
+#pragma mark - Non-canonical input (Rust returns error)
 
-// These inputs panic inside Rust `SecretKey::from_ed25519_bytes` and abort the
-// process via `panic_cannot_unwind`
-
-- (void)testAllZeroSecretShouldReturnError {
+- (void)testAllZeroSecretIsAccepted {
+    // schnorrkel 0.9.1 accepts all-zero 64-byte secret (zero scalar + zero nonce)
     NSMutableData *secret = [NSMutableData dataWithLength:kSecretSize];
     NSError *error = nil;
     SNPublicKey *publicKey = [self.keysFactory createPublicKeyFromSecret:secret error:&error];
-    XCTAssertNil(publicKey);
-    XCTAssertNotNil(error);
+    XCTAssertNotNil(publicKey);
+    XCTAssertNil(error);
 }
 
 - (void)testAllOnesSecretShouldReturnError {

--- a/Tests/SR25519/SNVrfTests.m
+++ b/Tests/SR25519/SNVrfTests.m
@@ -1,0 +1,224 @@
+//
+//  SNVrfTests.m
+//  IrohaCryptoTests
+//
+
+@import XCTest;
+#import "SNKeyFactory.h"
+#import "SNVrfSigner.h"
+#import "SNVrfVerifier.h"
+#import "SNVrfField.h"
+
+@interface SNVrfTests : XCTestCase
+
+@property(nonatomic, strong) SNKeyFactory *keyFactory;
+
+@end
+
+@implementation SNVrfTests
+
+- (void)setUp {
+    [super setUp];
+    _keyFactory = [[SNKeyFactory alloc] init];
+}
+
+- (void)tearDown {
+    _keyFactory = nil;
+    [super tearDown];
+}
+
+- (NSData*)labelData {
+    return [@"pop:airdrop" dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+- (NSArray<SNVrfField*>*)fieldsWithDomain:(NSData*)domain signer:(NSData*)signer {
+    return @[
+        [SNVrfField fieldWithKey:@"domain" value:domain],
+        [SNVrfField fieldWithKey:@"signer" value:signer]
+    ];
+}
+
+#pragma mark - Sign and verify roundtrip
+
+- (void)testSignAndVerifyRoundtrip {
+    uint8_t seedBytes[32];
+    memset(seedBytes, 0xAB, 32);
+    NSData *seed = [NSData dataWithBytes:seedBytes length:32];
+
+    NSError *error = nil;
+    SNKeypair *keypair = [_keyFactory createKeypairFromSeed:seed error:&error];
+    XCTAssertNotNil(keypair);
+    XCTAssertNil(error);
+
+    NSData *label = [self labelData];
+    uint8_t eventId[32];
+    memset(eventId, 0x07, 32);
+    NSMutableData *domain = [NSMutableData dataWithData:label];
+    [domain appendBytes:eventId length:32];
+
+    NSArray *fields = [self fieldsWithDomain:domain signer:keypair.publicKey.rawData];
+
+    SNVrfSigner *signer = [[SNVrfSigner alloc] initWithKeypair:keypair];
+    SNVrfSignature *signature = [signer signWithLabel:label fields:fields error:&error];
+    XCTAssertNotNil(signature);
+    XCTAssertNil(error);
+    XCTAssertEqual(signature.preOutput.length, SNVrfPreOutputSize);
+    XCTAssertEqual(signature.proof.length, SNVrfProofSize);
+
+    SNVrfVerifier *verifier = [[SNVrfVerifier alloc] init];
+    BOOL valid = [verifier verify:signature publicKey:keypair.publicKey label:label fields:fields];
+    XCTAssertTrue(valid);
+}
+
+#pragma mark - Deterministic pre-output
+
+- (void)testDeterministicPreOutput {
+    uint8_t seedBytes[32];
+    memset(seedBytes, 0xCD, 32);
+    NSData *seed = [NSData dataWithBytes:seedBytes length:32];
+
+    NSError *error = nil;
+    SNKeypair *keypair = [_keyFactory createKeypairFromSeed:seed error:&error];
+    XCTAssertNotNil(keypair);
+
+    NSData *label = [self labelData];
+    uint8_t eventId[32];
+    memset(eventId, 0x42, 32);
+    NSMutableData *domain = [NSMutableData dataWithData:label];
+    [domain appendBytes:eventId length:32];
+
+    NSArray *fields = [self fieldsWithDomain:domain signer:keypair.publicKey.rawData];
+    SNVrfSigner *signer = [[SNVrfSigner alloc] initWithKeypair:keypair];
+
+    SNVrfSignature *sig1 = [signer signWithLabel:label fields:fields error:&error];
+    SNVrfSignature *sig2 = [signer signWithLabel:label fields:fields error:&error];
+
+    XCTAssertEqualObjects(sig1.preOutput, sig2.preOutput);
+}
+
+#pragma mark - Verification rejects wrong inputs
+
+- (void)testVerifyFailsWithWrongPublicKey {
+    uint8_t seedBytes[32];
+    memset(seedBytes, 0x11, 32);
+    NSData *seed = [NSData dataWithBytes:seedBytes length:32];
+
+    uint8_t otherSeedBytes[32];
+    memset(otherSeedBytes, 0x22, 32);
+    NSData *otherSeed = [NSData dataWithBytes:otherSeedBytes length:32];
+
+    NSError *error = nil;
+    SNKeypair *keypair = [_keyFactory createKeypairFromSeed:seed error:&error];
+    SNKeypair *otherKeypair = [_keyFactory createKeypairFromSeed:otherSeed error:&error];
+
+    NSData *label = [self labelData];
+    NSData *domain = [@"test-domain" dataUsingEncoding:NSUTF8StringEncoding];
+    NSArray *fields = [self fieldsWithDomain:domain signer:keypair.publicKey.rawData];
+
+    SNVrfSigner *signer = [[SNVrfSigner alloc] initWithKeypair:keypair];
+    SNVrfSignature *signature = [signer signWithLabel:label fields:fields error:&error];
+    XCTAssertNotNil(signature);
+
+    SNVrfVerifier *verifier = [[SNVrfVerifier alloc] init];
+    BOOL valid = [verifier verify:signature publicKey:otherKeypair.publicKey label:label fields:fields];
+    XCTAssertFalse(valid);
+}
+
+- (void)testVerifyFailsWithWrongLabel {
+    uint8_t seedBytes[32];
+    memset(seedBytes, 0x33, 32);
+    NSData *seed = [NSData dataWithBytes:seedBytes length:32];
+
+    NSError *error = nil;
+    SNKeypair *keypair = [_keyFactory createKeypairFromSeed:seed error:&error];
+
+    NSData *label = [self labelData];
+    NSData *domain = [@"test-domain" dataUsingEncoding:NSUTF8StringEncoding];
+    NSArray *fields = [self fieldsWithDomain:domain signer:keypair.publicKey.rawData];
+
+    SNVrfSigner *signer = [[SNVrfSigner alloc] initWithKeypair:keypair];
+    SNVrfSignature *signature = [signer signWithLabel:label fields:fields error:&error];
+    XCTAssertNotNil(signature);
+
+    SNVrfVerifier *verifier = [[SNVrfVerifier alloc] init];
+    NSData *wrongLabel = [@"wrong:label" dataUsingEncoding:NSUTF8StringEncoding];
+    BOOL valid = [verifier verify:signature publicKey:keypair.publicKey label:wrongLabel fields:fields];
+    XCTAssertFalse(valid);
+}
+
+- (void)testVerifyFailsWithWrongDomain {
+    uint8_t seedBytes[32];
+    memset(seedBytes, 0x44, 32);
+    NSData *seed = [NSData dataWithBytes:seedBytes length:32];
+
+    NSError *error = nil;
+    SNKeypair *keypair = [_keyFactory createKeypairFromSeed:seed error:&error];
+
+    NSData *label = [self labelData];
+    NSData *domain = [@"correct-domain" dataUsingEncoding:NSUTF8StringEncoding];
+    NSArray *fields = [self fieldsWithDomain:domain signer:keypair.publicKey.rawData];
+
+    SNVrfSigner *signer = [[SNVrfSigner alloc] initWithKeypair:keypair];
+    SNVrfSignature *signature = [signer signWithLabel:label fields:fields error:&error];
+    XCTAssertNotNil(signature);
+
+    NSData *wrongDomain = [@"wrong-domain" dataUsingEncoding:NSUTF8StringEncoding];
+    NSArray<SNVrfField*> *wrongFields = [self fieldsWithDomain:wrongDomain signer:keypair.publicKey.rawData];
+
+    SNVrfVerifier *verifier = [[SNVrfVerifier alloc] init];
+    BOOL valid = [verifier verify:signature publicKey:keypair.publicKey label:label fields:wrongFields];
+    XCTAssertFalse(valid);
+}
+
+#pragma mark - VrfSignature raw data roundtrip
+
+- (void)testVrfSignatureRawDataRoundtrip {
+    uint8_t seedBytes[32];
+    memset(seedBytes, 0x55, 32);
+    NSData *seed = [NSData dataWithBytes:seedBytes length:32];
+
+    NSError *error = nil;
+    SNKeypair *keypair = [_keyFactory createKeypairFromSeed:seed error:&error];
+
+    NSData *label = [self labelData];
+    NSData *domain = [@"roundtrip" dataUsingEncoding:NSUTF8StringEncoding];
+    NSArray *fields = [self fieldsWithDomain:domain signer:keypair.publicKey.rawData];
+
+    SNVrfSigner *signer = [[SNVrfSigner alloc] initWithKeypair:keypair];
+    SNVrfSignature *original = [signer signWithLabel:label fields:fields error:&error];
+    XCTAssertNotNil(original);
+
+    NSData *raw = [original rawData];
+    XCTAssertEqual(raw.length, SNVrfPreOutputSize + SNVrfProofSize);
+
+    SNVrfSignature *restored = [[SNVrfSignature alloc] initWithRawData:raw error:&error];
+    XCTAssertNotNil(restored);
+    XCTAssertEqualObjects(original.preOutput, restored.preOutput);
+    XCTAssertEqualObjects(original.proof, restored.proof);
+}
+
+#pragma mark - Empty fields
+
+- (void)testSignAndVerifyWithEmptyFields {
+    uint8_t seedBytes[32];
+    memset(seedBytes, 0x66, 32);
+    NSData *seed = [NSData dataWithBytes:seedBytes length:32];
+
+    NSError *error = nil;
+    SNKeypair *keypair = [_keyFactory createKeypairFromSeed:seed error:&error];
+    XCTAssertNotNil(keypair);
+
+    NSData *label = [@"label-only" dataUsingEncoding:NSUTF8StringEncoding];
+    NSArray *fields = @[];
+
+    SNVrfSigner *signer = [[SNVrfSigner alloc] initWithKeypair:keypair];
+    SNVrfSignature *signature = [signer signWithLabel:label fields:fields error:&error];
+    XCTAssertNotNil(signature);
+    XCTAssertNil(error);
+
+    SNVrfVerifier *verifier = [[SNVrfVerifier alloc] init];
+    BOOL valid = [verifier verify:signature publicKey:keypair.publicKey label:label fields:fields];
+    XCTAssertTrue(valid);
+}
+
+@end

--- a/Tests/SR25519/SNVrfTests.m
+++ b/Tests/SR25519/SNVrfTests.m
@@ -8,6 +8,7 @@
 #import "SNVrfSigner.h"
 #import "SNVrfVerifier.h"
 #import "SNVrfField.h"
+#import "sr25519.h"
 
 @interface SNVrfTests : XCTestCase
 
@@ -62,8 +63,8 @@
     SNVrfSignature *signature = [signer signWithLabel:label fields:fields error:&error];
     XCTAssertNotNil(signature);
     XCTAssertNil(error);
-    XCTAssertEqual(signature.preOutput.length, SNVrfPreOutputSize);
-    XCTAssertEqual(signature.proof.length, SNVrfProofSize);
+    XCTAssertEqual(signature.preOutput.length, SR25519_VRF_OUTPUT_SIZE);
+    XCTAssertEqual(signature.proof.length, SR25519_VRF_PROOF_SIZE);
 
     SNVrfVerifier *verifier = [[SNVrfVerifier alloc] init];
     BOOL valid = [verifier verify:signature publicKey:keypair.publicKey label:label fields:fields];
@@ -189,7 +190,7 @@
     XCTAssertNotNil(original);
 
     NSData *raw = [original rawData];
-    XCTAssertEqual(raw.length, SNVrfPreOutputSize + SNVrfProofSize);
+    XCTAssertEqual(raw.length, SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE);
 
     SNVrfSignature *restored = [[SNVrfSignature alloc] initWithRawData:raw error:&error];
     XCTAssertNotNil(restored);


### PR DESCRIPTION
## Problem

The sr25519 Objective-C wrappers called C functions that panicked on invalid input — undefined behavior across FFI that crashes the iOS app. Invalid keypairs, secrets, or public keys would abort the process instead of returning errors. To prevent this, `SNKeyFactory` had to duplicate schnorrkel's internal scalar validation logic in Objective-C (canonical scalar check, high-bit guard, zero rejection), which was fragile and could drift from the Rust implementation.

Additionally, the library lacked VRF (Verifiable Random Function) support needed for the individuality airdrop pallet's `sign_up_with_invite` extrinsic, requiring a separate `AirdropVrf` xcframework as an extra dependency.

## Solution

Updated to the new sr25519.c which:
- Returns `Sr25519Result` error codes from all C functions instead of panicking, enabling proper `NSError` propagation
- Adds generic VRF sign/verify functions (`sr25519_generic_vrf_sign`, `sr25519_generic_vrf_verify`) that accept a caller-defined Merlin transcript (label + key-value fields), mirroring `sp_core::sr25519::vrf::VrfTranscript`

Crypto-iOS changes:
- All sr25519 wrappers (`SNKeyFactory`, `SNSigner`, `SNPrivateKey`) now check `Sr25519Result` and return `NSError` on failure
- Removed manual canonical scalar validation from `SNKeyFactory` — Rust handles this now
- `toEd25519Data` is now nullable (can fail gracefully)
- Added `SNVrfSigner`, `SNVrfVerifier`, `SNVrfSignature`, and `SNVrfField` — Objective-C wrappers for generic VRF operations, fully compatible with the individuality airdrop pallet's proof generation
- Added 7 VRF tests covering sign/verify roundtrip, determinism, wrong key/label/domain rejection, empty fields, and raw data serialization
